### PR TITLE
fix: query remove dry initializer

### DIFF
--- a/lib/boxenn/repositories/query.rb
+++ b/lib/boxenn/repositories/query.rb
@@ -1,13 +1,6 @@
-require 'dry/initializer'
-
 module Boxenn
   module Repositories
     class Query
-
-      extend Dry::Initializer
-
-      param :relation, default: proc { nil }
-
       def collect
         raise NotImplementedError
       end


### PR DESCRIPTION
closed #10 